### PR TITLE
Underhma patch 1

### DIFF
--- a/src/main/java/com/revature/chronicle/controller/FileUploadController.java
+++ b/src/main/java/com/revature/chronicle/controller/FileUploadController.java
@@ -1,4 +1,4 @@
-package com.revature.chronicle.Controller;
+package com.revature.chronicle.controller;
 
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/com/revature/chronicle/controller/NoteControllerTests.java
+++ b/src/test/java/com/revature/chronicle/controller/NoteControllerTests.java
@@ -1,4 +1,4 @@
-package com.revature.chronicle.Controller;
+package com.revature.chronicle.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.revature.chronicle.daos.TagRepo;

--- a/src/test/java/com/revature/chronicle/controller/S3ControllerTest.java
+++ b/src/test/java/com/revature/chronicle/controller/S3ControllerTest.java
@@ -1,4 +1,4 @@
-package com.revature.chronicle.Controller;
+package com.revature.chronicle.controller;
 
 import com.revature.chronicle.services.NoteService;
 import com.revature.chronicle.services.S3FileService;


### PR DESCRIPTION
The FileUploadController class's package name at the top had a capital c, although it sat in a lowercase c package. Also, the S3ControllerTest and NoteControllerTest followed the same pattern.

Changing the capital c to lowercase c in these classes allows the tests to run successfully. Pulling these changes may mean that the puller has to restart their IDE so that the file can reload and be detected on the classpath.